### PR TITLE
Improve activity log default range handling

### DIFF
--- a/cmspos-backend/cmspos-backend/src/main/java/net/cmspos/cmspos/repository/ActivityLogRepository.java
+++ b/cmspos-backend/cmspos-backend/src/main/java/net/cmspos/cmspos/repository/ActivityLogRepository.java
@@ -2,6 +2,7 @@ package net.cmspos.cmspos.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import net.cmspos.cmspos.model.entity.ActivityLog;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ import org.springframework.stereotype.Repository;
 public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long> {
     @EntityGraph(attributePaths = "user")
     List<ActivityLog> findByLogDateBetweenOrderByLogDateDesc(LocalDateTime start, LocalDateTime end);
+
+    Optional<ActivityLog> findTopByOrderByLogDateDesc();
 }


### PR DESCRIPTION
## Summary
- allow the dashboard activity log view to load even when no date range is specified and expose a shortcut to clear filters
- fall back to the most recent audit entry when computing default ranges so historic database data is still surfaced

## Testing
- npm run lint *(fails: existing prop-types errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfeb598ac8324ab71fe585d88f2e7