### PR TITLE
Fix activity log default date formatting

### DIFF
--- a/Frontend-MiniMart/src/layout/page/admin/ActivityLog.jsx
+++ b/Frontend-MiniMart/src/layout/page/admin/ActivityLog.jsx
@@ -4,12 +4,15 @@ import { fetchActivityLogs } from "../../../api/activityLogs";
 const AUTO_REFRESH_INTERVAL_MS = 10000;
 
 const formatDateInput = (date) => {
-  if (!(date instanceof Date)) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
     return "";
   }
   const copy = new Date(date);
   copy.setHours(0, 0, 0, 0);
-  return copy.toISOString().slice(0, 10);
+  const year = copy.getFullYear();
+  const month = String(copy.getMonth() + 1).padStart(2, "0");
+  const day = String(copy.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 };
 
 const formatDateTime = (value) => {


### PR DESCRIPTION
## Summary
- ensure the admin activity log normalizes date inputs using local calendar values so current-day activity is included
- keep the auto-refresh flow intact so login activity for admins, managers, and users is visible as it arrives

## Testing
- npm run lint *(fails: existing prop-types lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc08cdd59c8324a7e44786c5d2baf7