### PR TITLE
Add profit and loss reporting

### DIFF
--- a/cmspos-backend/cmspos-backend/src/main/java/net/cmspos/cmspos/controller/report/ReportController.java
+++ b/cmspos-backend/cmspos-backend/src/main/java/net/cmspos/cmspos/controller/report/ReportController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.cmspos.cmspos.model.dto.report.DailySalesSummaryDto;
 import net.cmspos.cmspos.model.dto.report.InventoryReportDto;
+import net.cmspos.cmspos.model.dto.report.ProfitLossReportDto;
 import net.cmspos.cmspos.model.dto.report.TopProductSalesDto;
 import net.cmspos.cmspos.service.ReportService;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -49,6 +50,17 @@ public class ReportController {
     @GetMapping("/inventory")
     public ResponseEntity<InventoryReportDto> getInventoryReport() {
         InventoryReportDto report = reportService.getInventoryReport();
+        return ResponseEntity.ok(report);
+    }
+
+    @GetMapping("/profit-loss")
+    public ResponseEntity<ProfitLossReportDto> getProfitAndLoss(
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @RequestParam(required = false) Long locationId) {
+        ProfitLossReportDto report = reportService.getProfitAndLoss(startDate, endDate, locationId);
         return ResponseEntity.ok(report);
     }
 }

--- a/cmspos-backend/cmspos-backend/src/main/java/net/cmspos/cmspos/model/dto/report/ExpenseSummaryDto.java
+++ b/cmspos-backend/cmspos-backend/src/main/java/net/cmspos/cmspos/model/dto/report/ExpenseSummaryDto.java
@@ -1,0 +1,18 @@
+package net.cmspos.cmspos.model.dto.report;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import net.cmspos.cmspos.model.enums.ExpenseCategory;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExpenseSummaryDto {
+    private ExpenseCategory category;
+    private double totalAmount;
+}

--- a/cmspos-backend/cmspos-backend/src/main/java/net/cmspos/cmspos/model/dto/report/ProfitLossProductDto.java
+++ b/cmspos-backend/cmspos-backend/src/main/java/net/cmspos/cmspos/model/dto/report/ProfitLossProductDto.java
@@ -1,0 +1,21 @@
+package net.cmspos.cmspos.model.dto.report;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProfitLossProductDto {
+    private Long productId;
+    private String productName;
+    private long quantitySold;
+    private double revenue;
+    private double costOfGoods;
+    private double grossProfit;
+}

--- a/cmspos-backend/cmspos-backend/src/main/java/net/cmspos/cmspos/model/dto/report/ProfitLossReportDto.java
+++ b/cmspos-backend/cmspos-backend/src/main/java/net/cmspos/cmspos/model/dto/report/ProfitLossReportDto.java
@@ -1,0 +1,27 @@
+package net.cmspos.cmspos.model.dto.report;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProfitLossReportDto {
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private double totalRevenue;
+    private double totalDiscounts;
+    private double costOfGoodsSold;
+    private double grossProfit;
+    private double totalExpenses;
+    private double netProfit;
+    private List<ProfitLossProductDto> productBreakdown;
+    private List<ExpenseSummaryDto> expenseBreakdown;
+}

--- a/cmspos-backend/cmspos-backend/src/main/java/net/cmspos/cmspos/service/ReportService.java
+++ b/cmspos-backend/cmspos-backend/src/main/java/net/cmspos/cmspos/service/ReportService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import net.cmspos.cmspos.model.dto.report.DailySalesSummaryDto;
 import net.cmspos.cmspos.model.dto.report.InventoryReportDto;
+import net.cmspos.cmspos.model.dto.report.ProfitLossReportDto;
 import net.cmspos.cmspos.model.dto.report.TopProductSalesDto;
 
 public interface ReportService {
@@ -12,4 +13,6 @@ public interface ReportService {
     List<TopProductSalesDto> getTopProducts(LocalDate startDate, LocalDate endDate, int limit, Long locationId);
 
     InventoryReportDto getInventoryReport();
+
+    ProfitLossReportDto getProfitAndLoss(LocalDate startDate, LocalDate endDate, Long locationId);
 }


### PR DESCRIPTION
## Summary
- add data transfer objects to represent profit & loss report payloads
- expose a new /reports/profit-loss endpoint that calls the report service
- calculate profit, COGS, and expense breakdowns from orders, purchases, and expenses

## Testing
- ./mvnw -q test *(fails: unable to download Maven distribution in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0ffd190c832494af9060043d4e70