### PR TITLE
Add profit and loss reporting UI

### DIFF
--- a/Frontend-MiniMart/src/api/reports.js
+++ b/Frontend-MiniMart/src/api/reports.js
@@ -1,0 +1,32 @@
+import { API_BASE_URL, buildAuthHeaders, handleJsonResponse } from "./http";
+
+const profitLossEndpoint = new URL("/reports/profit-loss", API_BASE_URL).toString();
+
+export const fetchProfitLossReport = async ({
+  startDate,
+  endDate,
+  locationId,
+  signal,
+} = {}) => {
+  const url = new URL(profitLossEndpoint);
+
+  if (startDate) {
+    url.searchParams.set("startDate", startDate);
+  }
+  if (endDate) {
+    url.searchParams.set("endDate", endDate);
+  }
+  if (locationId) {
+    url.searchParams.set("locationId", locationId);
+  }
+
+  const response = await fetch(url.toString(), {
+    signal,
+    headers: buildAuthHeaders({ Accept: "application/json" }),
+  });
+
+  return handleJsonResponse(
+    response,
+    "Failed to load profit and loss report"
+  );
+};

--- a/Frontend-MiniMart/src/layout/page/reports/Reports.jsx
+++ b/Frontend-MiniMart/src/layout/page/reports/Reports.jsx
@@ -2,8 +2,15 @@ import "./reports.css";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import posConfig from "../../../config/posConfig";
 import { fetchOrders } from "../../../api/orders";
+import { fetchProfitLossReport } from "../../../api/reports";
+import { fetchLocations } from "../../../api/locations";
 
 const { currencySymbol: CURRENCY_SYMBOL } = posConfig;
+
+const TAB_KEYS = {
+  PROFIT_LOSS: "profit-loss",
+  SALES: "sales",
+};
 
 const formatCurrency = (value) =>
   CURRENCY_SYMBOL +
@@ -16,6 +23,48 @@ const formatNumber = (value) =>
   Number(value ?? 0).toLocaleString(undefined, {
     maximumFractionDigits: 0,
   });
+
+const formatPercent = (value) =>
+  new Intl.NumberFormat(undefined, {
+    style: "percent",
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(Number.isFinite(value) ? value : 0);
+
+const formatDateInput = (date) => {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return "";
+  }
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const formatDisplayDate = (value) => {
+  if (!value) return "";
+  const [year, month, day] = String(value).split("-");
+  if (!year || !month || !day) {
+    return value;
+  }
+  const date = new Date(Number(year), Number(month) - 1, Number(day));
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+  });
+};
+
+const formatEnumLabel = (value) =>
+  !value
+    ? ""
+    : String(value)
+        .split("_")
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+        .join(" ");
 
 const normalizeStatus = (value) => (value ? String(value).toUpperCase() : "");
 
@@ -282,7 +331,7 @@ const SalesSummary = () => {
             onClick={handleRefresh}
             disabled={loading}
           >
-            {loading ? "Refreshing…" : "Refresh data"}
+            {loading ? "RefreshingÂ…" : "Refresh data"}
           </button>
         </div>
       </header>
@@ -457,7 +506,7 @@ const SalesSummary = () => {
               )}
               {recentOrders.map((order) => (
                 <tr key={order.orderId ?? order.id}>
-                  <td>{order.orderId ?? order.id ?? "—"}</td>
+                  <td>{order.orderId ?? order.id ?? "Â—"}</td>
                   <td>{order?.customer?.name ?? "Walk-in"}</td>
                   <td className="text-end">{formatCurrency(order.total)}</td>
                   <td>
@@ -470,7 +519,7 @@ const SalesSummary = () => {
                           : "secondary"
                       }`}
                     >
-                      {normalizeStatus(order.paymentStatus) || "—"}
+                      {normalizeStatus(order.paymentStatus) || "Â—"}
                     </span>
                   </td>
                   <td>
@@ -479,14 +528,14 @@ const SalesSummary = () => {
                       month: "short",
                       hour: "2-digit",
                       minute: "2-digit",
-                    }) ?? "—"}
+                    }) ?? "Â—"}
                   </td>
                 </tr>
               ))}
               {loading && (
                 <tr>
                   <td colSpan={5} className="text-center text-secondary py-4">
-                    Loading orders…
+                    Loading ordersÂ…
                   </td>
                 </tr>
               )}
@@ -498,4 +547,491 @@ const SalesSummary = () => {
   );
 };
 
-export default SalesSummary;
+const ProfitLossReport = () => {
+  const [filters, setFilters] = useState(() => {
+    const today = new Date();
+    const start = new Date(today);
+    start.setMonth(start.getMonth() - 1);
+    return {
+      startDate: formatDateInput(start),
+      endDate: formatDateInput(today),
+      locationId: "",
+    };
+  });
+  const [report, setReport] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [locations, setLocations] = useState([]);
+  const [lastUpdated, setLastUpdated] = useState(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetchLocations({ signal: controller.signal })
+      .then((data) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setLocations(Array.isArray(data) ? data : []);
+      })
+      .catch(() => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setLocations([]);
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    if (
+      filters.startDate &&
+      filters.endDate &&
+      filters.startDate > filters.endDate
+    ) {
+      setError("Start date must be on or before the end date.");
+      setReport(null);
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    setLastUpdated(null);
+
+    fetchProfitLossReport({
+      startDate: filters.startDate || undefined,
+      endDate: filters.endDate || undefined,
+      locationId: filters.locationId || undefined,
+      signal: controller.signal,
+    })
+      .then((data) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setReport(data ?? null);
+        setLastUpdated(new Date());
+      })
+      .catch((err) => {
+        if (err.name === "AbortError") {
+          return;
+        }
+        setError(
+          err.message || "Unable to load profit and loss report."
+        );
+        setReport(null);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [filters.startDate, filters.endDate, filters.locationId, refreshKey]);
+
+  const locationOptions = useMemo(
+    () =>
+      (locations ?? []).map((location) => ({
+        id:
+          location?.locationId === undefined ||
+          location?.locationId === null
+            ? ""
+            : String(location.locationId),
+        name:
+          location?.name ??
+          `Location ${location?.locationId ?? ""}`,
+      })),
+    [locations]
+  );
+
+  const activeLocationLabel = useMemo(() => {
+    if (!filters.locationId) {
+      return "All locations";
+    }
+    const match = locationOptions.find(
+      (option) => option.id === filters.locationId
+    );
+    return match?.name ?? "Selected location";
+  }, [filters.locationId, locationOptions]);
+
+  const handleFilterChange = (event) => {
+    const { name, value } = event.target;
+    setFilters((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleRefresh = () => {
+    setRefreshKey((prev) => prev + 1);
+  };
+
+  const totalRevenue = Number(report?.totalRevenue ?? 0);
+  const totalDiscounts = Number(report?.totalDiscounts ?? 0);
+  const costOfGoodsSold = Number(report?.costOfGoodsSold ?? 0);
+  const grossProfit = Number(report?.grossProfit ?? 0);
+  const totalExpenses = Number(report?.totalExpenses ?? 0);
+  const netProfit = Number(report?.netProfit ?? 0);
+  const productBreakdown = report?.productBreakdown ?? [];
+  const expenseBreakdown = report?.expenseBreakdown ?? [];
+
+  const grossMargin = totalRevenue !== 0 ? grossProfit / totalRevenue : 0;
+  const netMargin = totalRevenue !== 0 ? netProfit / totalRevenue : 0;
+  const discountRate = totalRevenue !== 0 ? totalDiscounts / totalRevenue : 0;
+  const expenseShare = totalRevenue !== 0 ? totalExpenses / totalRevenue : 0;
+  const costShare = totalRevenue !== 0 ? costOfGoodsSold / totalRevenue : 0;
+
+  const topProduct = productBreakdown[0];
+  const topExpense = expenseBreakdown[0];
+
+  const resolvedStart = report?.startDate ?? filters.startDate;
+  const resolvedEnd = report?.endDate ?? filters.endDate;
+
+  const periodLabel = useMemo(() => {
+    const formattedStart = formatDisplayDate(resolvedStart);
+    const formattedEnd = formatDisplayDate(resolvedEnd);
+    if (formattedStart && formattedEnd) {
+      return `${formattedStart} â€“ ${formattedEnd}`;
+    }
+    return formattedStart || formattedEnd || "";
+  }, [resolvedStart, resolvedEnd]);
+
+  const isReportEmpty =
+    !loading &&
+    !error &&
+    report &&
+    totalRevenue === 0 &&
+    totalExpenses === 0 &&
+    costOfGoodsSold === 0 &&
+    productBreakdown.length === 0 &&
+    expenseBreakdown.length === 0;
+
+  return (
+    <div className="profit-loss-report">
+      <header className="summary-header">
+        <div>
+          <h2 className="mb-1">Profit &amp; Loss</h2>
+          <p className="text-secondary mb-2">
+            Combined revenue, cost of goods, and expense insights sourced from
+            paid orders, purchase orders, and expense tracking.
+          </p>
+          <div className="profit-loss-meta">
+            {periodLabel && <span>Period: {periodLabel}</span>}
+            <span>Location: {activeLocationLabel}</span>
+          </div>
+        </div>
+        <div className="summary-header-actions profit-loss-actions">
+          {lastUpdated && (
+            <span className="badge bg-secondary-subtle text-secondary">
+              Updated {lastUpdated.toLocaleString()}
+            </span>
+          )}
+          <div className="profit-loss-filters">
+            <div className="profit-loss-field">
+              <label htmlFor="profit-loss-start">Start date</label>
+              <input
+                id="profit-loss-start"
+                type="date"
+                name="startDate"
+                value={filters.startDate}
+                onChange={handleFilterChange}
+                className="form-control form-control-sm"
+                max={filters.endDate || undefined}
+              />
+            </div>
+            <div className="profit-loss-field">
+              <label htmlFor="profit-loss-end">End date</label>
+              <input
+                id="profit-loss-end"
+                type="date"
+                name="endDate"
+                value={filters.endDate}
+                onChange={handleFilterChange}
+                className="form-control form-control-sm"
+                min={filters.startDate || undefined}
+              />
+            </div>
+            <div className="profit-loss-field">
+              <label htmlFor="profit-loss-location">Location</label>
+              <select
+                id="profit-loss-location"
+                name="locationId"
+                value={filters.locationId}
+                onChange={handleFilterChange}
+                className="form-select form-select-sm"
+              >
+                <option value="">All locations</option>
+                {locationOptions.map((option) => (
+                  <option key={option.id || "default"} value={option.id}>
+                    {option.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <button
+            type="button"
+            className="btn btn-primary btn-sm"
+            onClick={handleRefresh}
+            disabled={loading}
+          >
+            {loading ? "Refreshing" : "Refresh report"}
+          </button>
+        </div>
+      </header>
+
+      {error && <div className="alert alert-danger mb-0">{error}</div>}
+      {isReportEmpty && (
+        <div className="alert alert-secondary mb-0">
+          No profit and loss data is available for the selected filters yet.
+        </div>
+      )}
+
+      <section className="summary-kpis">
+        <article className="summary-kpi-card">
+          <div className="kpi-heading">Total revenue</div>
+          <div className="kpi-value">{formatCurrency(totalRevenue)}</div>
+          <div className="kpi-subtitle text-secondary">
+            Gross sales from paid orders within the selected period
+          </div>
+        </article>
+        <article className="summary-kpi-card">
+          <div className="kpi-heading">Discounts applied</div>
+          <div className="kpi-value">{formatCurrency(totalDiscounts)}</div>
+          <div className="kpi-subtitle text-secondary">
+            Discount rate: {formatPercent(discountRate)} of revenue
+          </div>
+        </article>
+        <article className="summary-kpi-card">
+          <div className="kpi-heading">Cost of goods sold</div>
+          <div className="kpi-value">{formatCurrency(costOfGoodsSold)}</div>
+          <div className="kpi-subtitle text-secondary">
+            Share of revenue: {formatPercent(costShare)}
+          </div>
+        </article>
+        <article className="summary-kpi-card">
+          <div className="kpi-heading">Gross profit</div>
+          <div className="kpi-value">{formatCurrency(grossProfit)}</div>
+          <div className="kpi-subtitle text-secondary">
+            Gross margin: {formatPercent(grossMargin)}
+          </div>
+        </article>
+        <article className="summary-kpi-card">
+          <div className="kpi-heading">Operating expenses</div>
+          <div className="kpi-value">{formatCurrency(totalExpenses)}</div>
+          <div className="kpi-subtitle text-secondary">
+            Expense share: {formatPercent(expenseShare)} of revenue
+          </div>
+        </article>
+        <article className="summary-kpi-card">
+          <div className="kpi-heading">Net profit</div>
+          <div
+            className={`kpi-value ${
+              netProfit >= 0 ? "text-success" : "text-danger"
+            }`}
+          >
+            {formatCurrency(netProfit)}
+          </div>
+          <div className="kpi-subtitle text-secondary">
+            Net margin: {formatPercent(netMargin)}
+          </div>
+        </article>
+      </section>
+
+      <section className="summary-panel">
+        <div className="panel-header">
+          <div>
+            <h6 className="mb-0">Profitability insights</h6>
+            <span className="text-secondary small">
+              Ratios and highlights derived from aggregated totals
+            </span>
+          </div>
+        </div>
+        <ul className="profit-loss-insights">
+          <li>
+            <strong>Gross margin:</strong> {formatPercent(grossMargin)} of
+            revenue after accounting for cost of goods.
+          </li>
+          <li>
+            <strong>Net margin:</strong> {formatPercent(netMargin)} retained
+            after expenses.
+          </li>
+          <li>
+            <strong>Top product:</strong>{" "}
+            {topProduct
+              ? `${topProduct.productName} (${formatCurrency(
+                  topProduct.grossProfit
+                )} gross profit)`
+              : "No product sales recorded."}
+          </li>
+          <li>
+            <strong>Top expense category:</strong>{" "}
+            {topExpense
+              ? `${formatEnumLabel(topExpense.category)} (${formatCurrency(
+                  topExpense.totalAmount
+                )})`
+              : "No expenses recorded."}
+          </li>
+        </ul>
+      </section>
+
+      <section className="profit-loss-grid">
+        <article className="summary-panel profit-loss-table">
+          <div className="panel-header">
+            <div>
+              <h6 className="mb-0">Product profitability</h6>
+              <span className="text-secondary small">
+                Revenue, costs, and gross profit per product
+              </span>
+            </div>
+          </div>
+          <div className="table-responsive">
+            <table className="table table-hover align-middle mb-0">
+              <thead className="table-light">
+                <tr>
+                  <th scope="col">Product</th>
+                  <th scope="col" className="text-end">
+                    Qty sold
+                  </th>
+                  <th scope="col" className="text-end">
+                    Revenue
+                  </th>
+                  <th scope="col" className="text-end">
+                    Cost of goods
+                  </th>
+                  <th scope="col" className="text-end">
+                    Gross profit
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {productBreakdown.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="profit-loss-empty">
+                      No product sales were recorded for this period.
+                    </td>
+                  </tr>
+                )}
+                {productBreakdown.map((product) => (
+                  <tr key={product.productId ?? product.productName}>
+                    <td>{product.productName}</td>
+                    <td className="text-end">
+                      {formatNumber(product.quantitySold)}
+                    </td>
+                    <td className="text-end">
+                      {formatCurrency(product.revenue)}
+                    </td>
+                    <td className="text-end">
+                      {formatCurrency(product.costOfGoods)}
+                    </td>
+                    <td
+                      className={`text-end ${
+                        product.grossProfit >= 0
+                          ? "text-success"
+                          : "text-danger"
+                      }`}
+                    >
+                      {formatCurrency(product.grossProfit)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+
+        <article className="summary-panel profit-loss-table">
+          <div className="panel-header">
+            <div>
+              <h6 className="mb-0">Expense breakdown</h6>
+              <span className="text-secondary small">
+                Total expense amount by category for the selected period
+              </span>
+            </div>
+          </div>
+          <div className="table-responsive">
+            <table className="table table-hover align-middle mb-0">
+              <thead className="table-light">
+                <tr>
+                  <th scope="col">Category</th>
+                  <th scope="col" className="text-end">
+                    Total amount
+                  </th>
+                  <th scope="col" className="text-end">
+                    Share of expenses
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {expenseBreakdown.length === 0 && (
+                  <tr>
+                    <td colSpan={3} className="profit-loss-empty">
+                      No expenses were recorded for this period.
+                    </td>
+                  </tr>
+                )}
+                {expenseBreakdown.map((entry) => {
+                  const share =
+                    totalExpenses === 0
+                      ? 0
+                      : Number(entry.totalAmount ?? 0) / totalExpenses;
+                  return (
+                    <tr key={entry.category ?? "uncategorized"}>
+                      <td>{formatEnumLabel(entry.category) || "Other"}</td>
+                      <td className="text-end">
+                        {formatCurrency(entry.totalAmount)}
+                      </td>
+                      <td className="text-end">
+                        {formatPercent(share)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </article>
+      </section>
+    </div>
+  );
+};
+
+const Reports = () => {
+  const [activeTab, setActiveTab] = useState(TAB_KEYS.PROFIT_LOSS);
+
+  const tabs = [
+    { key: TAB_KEYS.PROFIT_LOSS, label: "Profit & Loss" },
+    { key: TAB_KEYS.SALES, label: "Sales Summary" },
+  ];
+
+  return (
+    <div className="reports-page">
+      <div className="reports-tabs">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            className={`reports-tab ${
+              activeTab === tab.key ? "active" : ""
+            }`}
+            onClick={() => setActiveTab(tab.key)}
+            aria-pressed={activeTab === tab.key}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      {activeTab === TAB_KEYS.PROFIT_LOSS ? (
+        <ProfitLossReport />
+      ) : (
+        <SalesSummary />
+      )}
+    </div>
+  );
+};
+
+export default Reports;

--- a/Frontend-MiniMart/src/layout/page/reports/reports.css
+++ b/Frontend-MiniMart/src/layout/page/reports/reports.css
@@ -1,3 +1,38 @@
+.reports-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.reports-tabs {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.reports-tab {
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  background: transparent;
+  color: #475569;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  transition: all 0.2s ease;
+}
+
+.reports-tab:hover {
+  border-color: #2563eb;
+  color: #2563eb;
+}
+
+.reports-tab.active {
+  background: linear-gradient(90deg, #2563eb, #1d4ed8);
+  border-color: transparent;
+  color: #ffffff;
+  box-shadow: 0 12px 28px rgba(37, 99, 235, 0.24);
+}
+
 .sales-summary-page {
   display: flex;
   flex-direction: column;
@@ -29,6 +64,57 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1rem;
+}
+
+.profit-loss-report {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.profit-loss-actions {
+  align-items: stretch;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.profit-loss-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.profit-loss-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 160px;
+}
+
+.profit-loss-field label {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.profit-loss-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.profit-loss-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(15, 23, 42, 0.06);
+  border-radius: 999px;
+  padding: 0.3rem 0.8rem;
 }
 
 .summary-kpi-card {
@@ -72,6 +158,47 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.profit-loss-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.profit-loss-table table thead th {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #6b7280;
+}
+
+.profit-loss-table table tbody td {
+  color: #1f2937;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.profit-loss-insights {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  color: #475569;
+  font-size: 0.92rem;
+}
+
+.profit-loss-insights li strong {
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.profit-loss-empty {
+  text-align: center;
+  color: #64748b;
+  padding: 1.1rem 0;
+  font-size: 0.9rem;
 }
 
 .panel-header {
@@ -229,5 +356,19 @@
   .peak-hours-row {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .profit-loss-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .profit-loss-filters {
+    width: 100%;
+  }
+
+  .profit-loss-field {
+    flex: 1 1 140px;
+    min-width: 0;
   }
 }


### PR DESCRIPTION
## Summary
- add a Profit & Loss tab with period and location filters that mirrors the new backend reporting payload
- surface aggregated totals, profitability insights, and per-product/expense breakdown tables driven by the /reports/profit-loss API
- refresh the reports page styling to support tab navigation between Profit & Loss and the existing Sales Summary view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd14530fbc83248209341fb98538ee